### PR TITLE
experiment producer/consumer for etcd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,14 @@ cluster-delete:
 maroon-logs:
 	kubectl logs -l app=maroon --follow --prefix
 
+cluster-add-delays:
+	for node in $$(docker ps --filter "name=oltp-multi-region-work*" --format "{{.Names}}"); do \
+    	echo "Adding delay to $$node"; \
+    	docker exec "$$node" tc qdisc add dev eth0 root netem delay 50ms; \
+	done
+
+cluster-remove-delays:
+	for node in $$(docker ps --filter "name=oltp-multi-region-work*" --format "{{.Names}}"); do \
+		echo "Removing delay from $$node"; \
+		docker exec "$$node" tc qdisc del dev eth0 root || true; \
+	done

--- a/scripts/test/etcd-load-test/consumer/main.go
+++ b/scripts/test/etcd-load-test/consumer/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	hashesKey = "/maroon/hashes"
+)
+
+func main() {
+	endpoints := []string{} //strings.Split(os.Getenv("ETCD_ENDPOINTS"), ",")
+	if len(endpoints) == 0 {
+		endpoints = []string{"http://localhost:2379"}
+	}
+
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		log.Fatalf("failed to create etcd client: %v", err)
+	}
+	defer cli.Close()
+
+	watchCh := cli.Watch(context.Background(), hashesKey, clientv3.WithPrefix())
+
+	log.Printf("Starting to watch %s...", hashesKey)
+
+	var counter int
+	for resp := range watchCh {
+		for _, ev := range resp.Events {
+
+			switch ev.Type {
+			case clientv3.EventTypePut:
+				counter++
+				log.Println("got: ", counter)
+				// log.Printf("New hash: %s = %s", string(ev.Kv.Key), string(ev.Kv.Value))
+			case clientv3.EventTypeDelete:
+				log.Printf("Deleted hash: %s", string(ev.Kv.Key))
+			}
+		}
+	}
+}

--- a/scripts/test/etcd-load-test/main.go
+++ b/scripts/test/etcd-load-test/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	leaderKey = "/maroon/leader"
+	hashesKey = "/maroon/hashes"
+)
+
+func main() {
+	endpoints := []string{} //strings.Split(os.Getenv("ETCD_ENDPOINTS"), ",")
+	if len(endpoints) == 0 {
+		endpoints = []string{"http://localhost:2379"}
+	}
+
+	log.Printf("Connecting to etcd endpoints: %v", endpoints)
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		log.Fatalf("failed to create etcd client: %v", err)
+	}
+	defer cli.Close()
+
+	// Test connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = cli.Status(ctx, endpoints[0])
+	if err != nil {
+		log.Fatalf("failed to connect to etcd: %v", err)
+	}
+	log.Println("Successfully connected to etcd")
+
+	log.Println("Attempting to grant lease...")
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lease, err := cli.Grant(ctx, 10)
+	if err != nil {
+		log.Fatalf("failed to create lease: %v", err)
+	}
+	log.Printf("Successfully granted lease with ID: %d", lease.ID)
+
+	log.Println("try to become leader")
+	leaderID := "node-1"
+
+	getResp, err := cli.Get(context.Background(), leaderKey)
+	if err != nil {
+		log.Fatalf("failed to check leader key: %v", err)
+	}
+	log.Printf("%#v", getResp)
+
+	resp, err := cli.Txn(context.Background()).
+		If(clientv3.Compare(clientv3.Version(leaderKey), "=", 0)).
+		Then(clientv3.OpPut(leaderKey, leaderID, clientv3.WithLease(lease.ID))).
+		Else(clientv3.OpGet(leaderKey)).
+		Commit()
+	if err != nil {
+		log.Fatalf("failed to try become leader: %v", err)
+	}
+
+	if !resp.Succeeded {
+		currentLeader := string(resp.Responses[0].GetResponseRange().Kvs[0].Value)
+		log.Fatalf("failed to become leader, current leader is: %s", currentLeader)
+	}
+
+	log.Println("Successfully became leader")
+
+	log.Println("keep lease alive")
+	keepAliveCh, err := cli.KeepAlive(context.Background(), lease.ID)
+	if err != nil {
+		log.Fatalf("failed to keep lease alive: %v", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+
+	ticker := time.NewTicker(1 * time.Millisecond)
+	defer ticker.Stop()
+	var counter int
+	for {
+		select {
+		case <-ticker.C:
+			timestamp := time.Now().Unix()
+			hash := sha256.Sum256([]byte(strconv.FormatInt(timestamp, 10)))
+			hashStr := fmt.Sprintf("%x", hash)
+
+			// Write hash with transaction
+			key := fmt.Sprintf("%s/%d", hashesKey, timestamp)
+			_, err = cli.Txn(context.Background()).
+				If(clientv3.Compare(clientv3.Value(leaderKey), "=", leaderID)).
+				Then(clientv3.OpPut(key, hashStr)).
+				Commit()
+			if err != nil {
+				log.Printf("failed to write hash: %v", err)
+				continue
+			}
+			counter++
+			// log.Printf("Written hash for timestamp %d: %s", timestamp, hashStr)
+			log.Println("counter: ", counter)
+
+		case _, ok := <-keepAliveCh:
+			if !ok {
+				log.Fatal("lost lease")
+			}
+
+		case <-sigCh:
+			log.Println("Shutting down...")
+			return
+		}
+	}
+}


### PR DESCRIPTION
Я потестил etcd. Тест был вида


скрипт-продьюсер
```
_, err = cli.Txn(context.Background()).
	If(clientv3.Compare(clientv3.Value(leaderKey), "=", leaderID)).
	Then(clientv3.OpPut(fmt.Sprintf("/maroon/hashes/%d", timestamp), hashStr)).
	Commit()
```

скрипт-консьюмер
```
watchCh := cli.Watch(context.Background(), "/maroon/hashes", clientv3.WithPrefix())
```

Все на моем ноуте: m3 pro. В докере, имитация k8s кластера, 3 ноды

без доп задержек на сеть ~630 RPS

задержки на сеть выставлял вот так
```
docker exec "$containerID" tc qdisc add dev eth0 root netem delay 75ms
```
это в одну сторону, RTT - 150ms


c задержкой в 
75ms(RTT-150) ~4 RPS 
50ms(RTT-100) ~6 RPS
20ms(RTT-40)  ~15 RPS
0ms 		  ~630RPS



Чет как-то не то что бы супер быстро. 15/sec это еле-еле. И это на довольно хороших условиях.
Ну или я что-то в тесте косякнул
